### PR TITLE
remove case sensitivity for item name, quality, unusual effect and skin

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -59,7 +59,7 @@ class Schema {
     getItemByItemName (name) {
         for (let i = 0; i < this.raw.schema.items.length; i++) {
             const item = this.raw.schema.items[i];
-            if (item.item_name === name) {
+            if (item.item_name.toLowerCase() === name.toLowerCase()) {
                 return item;
             }
         }
@@ -130,7 +130,7 @@ class Schema {
                 continue;
             }
 
-            if (this.raw.schema.qualityNames[type] === name) {
+            if (this.raw.schema.qualityNames[type].toLowerCase() === name.toLowerCase()) {
                 return this.raw.schema.qualities[type];
             }
         }
@@ -182,7 +182,7 @@ class Schema {
         for (let i = 0; i < this.raw.schema.attribute_controlled_attached_particles.length; i++) {
             const effect = this.raw.schema.attribute_controlled_attached_particles[i];
 
-            if (effect.name === name) {
+            if (effect.name.toLowerCase() === name.toLowerCase()) {
                 return effect.id;
             }
         }
@@ -214,7 +214,7 @@ class Schema {
                 continue;
             }
 
-            if (this.raw.schema.paintkits[id] === name) {
+            if (this.raw.schema.paintkits[id].toLowerCase() === name.toLowerCase()) {
                 return parseInt(id);
             }
         }


### PR DESCRIPTION
This fix allows schema searches for item names, qualities, unusual effects, and skins/paintkits to be case insensitive.